### PR TITLE
fix: reset stale fallback state for fresh-start on new project path

### DIFF
--- a/scripts/start_bridge.py
+++ b/scripts/start_bridge.py
@@ -10,6 +10,8 @@ from _bridge_common import (
     clear_error_fields,
     format_lifecycle_sync_state_note,
     has_pending_issue_centric_codex_dispatch,
+    load_state,
+    resolve_unified_next_action,
     save_state,
 )
 
@@ -219,6 +221,69 @@ def recover_resume_from_pending_issue_centric_codex_dispatch(args: argparse.Name
     return True
 
 
+def _is_safe_stale_fallback_state(state: dict) -> bool:
+    """Return True when the state is a stale no-action fallback with nothing genuinely pending.
+
+    This detects the case where a previous run (e.g. rehearsal) left the state at
+    mode=awaiting_user with old issue-centric fields, which causes resolve_unified_next_action()
+    to return 'no_action' and blocks fresh-start for a new project.
+
+    Safe to reset when ALL of the following hold:
+      - resolve_unified_next_action() == 'no_action'  (bridge is already stuck)
+      - error=false, pause=false                       (no error recovery in progress)
+      - no pending_request_hash                        (no unsent request)
+      - no pending_handoff_hash                        (no handoff in flight)
+      - no last_issue_centric_pending_generation_id    (no pending Codex run)
+      - no last_issue_centric_prepared_generation_id   (no prepared Codex body)
+      - mode NOT in active Codex lifecycle states
+    """
+    _active_codex_modes = {"ready_for_codex", "codex_running", "codex_done"}
+    if str(state.get("mode", "")).strip() in _active_codex_modes:
+        return False
+    if bool(state.get("error")):
+        return False
+    if bool(state.get("pause")):
+        return False
+    if str(state.get("pending_request_hash", "")).strip():
+        return False
+    if str(state.get("pending_handoff_hash", "")).strip():
+        return False
+    if str(state.get("last_issue_centric_pending_generation_id", "")).strip():
+        return False
+    if str(state.get("last_issue_centric_prepared_generation_id", "")).strip():
+        return False
+    return resolve_unified_next_action(state) == "no_action"
+
+
+def reset_stale_fallback_for_fresh_start(args: argparse.Namespace) -> bool:
+    """Reset stale no-action fallback state to allow fresh-start on the new target repo.
+
+    When start_bridge.py is called for a new project (e.g. PromptWeave after rehearsal),
+    the old state.json may have mode=awaiting_user + stale issue-centric fields that
+    cause resolve_unified_next_action() to return 'no_action', blocking fresh-start.
+
+    If the state is safe to reset (nothing genuinely pending), transition to
+    mode=idle + need_chatgpt_prompt=True so the normal fresh-start path proceeds.
+
+    Returns True if a reset was applied, False otherwise.
+    """
+    if args.status or args.doctor or args.clear_error:
+        return False
+    state = load_state()
+    if not _is_safe_stale_fallback_state(state):
+        return False
+    updated = dict(state)
+    updated["mode"] = "idle"
+    updated["need_chatgpt_prompt"] = True
+    save_state(updated)
+    print(
+        "bridge start: stale fallback state (no_action / 保留なし) を検出しました。"
+        " mode=idle + need_chatgpt_prompt=True にリセットして fresh-start へ進みます。",
+        flush=True,
+    )
+    return True
+
+
 def main(argv: list[str] | None = None) -> int:
     args = parse_args(argv)
     project_config = run_until_stop.load_project_config()
@@ -233,6 +298,7 @@ def main(argv: list[str] | None = None) -> int:
     if args.clear_error:
         return clear_error_for_resume(args)
     recover_resume_from_pending_issue_centric_codex_dispatch(args)
+    reset_stale_fallback_for_fresh_start(args)
     print("bridge start: このコマンドが通常入口です。", flush=True)
     print(f"- project_path: {project_path_display}", flush=True)
     print(f"- max_execution_count: {args.max_execution_count}", flush=True)

--- a/tests/test_start_bridge_stale_fallback_reset.py
+++ b/tests/test_start_bridge_stale_fallback_reset.py
@@ -1,0 +1,196 @@
+"""Tests for start_bridge.reset_stale_fallback_for_fresh_start().
+
+Covers the fix for: rehearsal runtime state (mode=awaiting_user + stale
+last_issue_centric_* fields) blocking fresh-start on a new target repo.
+"""
+from __future__ import annotations
+
+import argparse
+import json
+import sys
+import tempfile
+import unittest
+from pathlib import Path
+
+REPO_ROOT = Path(__file__).resolve().parents[1]
+SCRIPTS_DIR = REPO_ROOT / "scripts"
+sys.path.insert(0, str(SCRIPTS_DIR))
+
+import _bridge_common  # noqa: E402
+import start_bridge  # noqa: E402
+
+
+def _make_bridge_env(root: Path) -> dict:
+    """Create minimal bridge directory structure and return a fake config."""
+    (root / "bridge" / "inbox").mkdir(parents=True)
+    (root / "bridge" / "outbox").mkdir(parents=True)
+    (root / "bridge" / "history").mkdir(parents=True)
+    (root / "logs").mkdir(parents=True)
+    return {"bridge_runtime_root": str(root)}
+
+
+def _stale_rehearsal_state(**overrides: object) -> dict:
+    """Return a state that mimics rehearsal completion leftover (awaiting_user + stale fields)."""
+    state = _bridge_common.DEFAULT_STATE.copy()
+    state.update(
+        mode="awaiting_user",
+        need_chatgpt_prompt=False,
+        need_chatgpt_next=False,
+        last_issue_centric_target_issue="#9",
+        last_issue_centric_close_status="closed",
+        last_issue_centric_stop_reason=(
+            "parent issue #1 received a completion comment after issue #9 closed."
+        ),
+        last_issue_centric_runtime_mode="issue_centric_degraded_fallback",
+        last_issue_centric_generation_lifecycle="issue_centric_invalidated",
+        error=False,
+        pause=False,
+    )
+    state.update(overrides)
+    return state
+
+
+def _args(status: bool = False, doctor: bool = False, clear_error: bool = False) -> argparse.Namespace:
+    return argparse.Namespace(status=status, doctor=doctor, clear_error=clear_error)
+
+
+class StaleFallbackDetectionTests(unittest.TestCase):
+    """_is_safe_stale_fallback_state() correctly identifies the problematic state."""
+
+    def test_stale_awaiting_user_with_no_pending_is_safe(self) -> None:
+        state = _stale_rehearsal_state()
+        self.assertTrue(start_bridge._is_safe_stale_fallback_state(state))
+
+    def test_active_codex_mode_is_not_safe(self) -> None:
+        for active_mode in ("ready_for_codex", "codex_running", "codex_done"):
+            state = _stale_rehearsal_state(mode=active_mode)
+            self.assertFalse(
+                start_bridge._is_safe_stale_fallback_state(state),
+                f"mode={active_mode} should not be safe to reset",
+            )
+
+    def test_error_state_is_not_safe(self) -> None:
+        state = _stale_rehearsal_state(error=True, error_message="some error")
+        self.assertFalse(start_bridge._is_safe_stale_fallback_state(state))
+
+    def test_pause_state_is_not_safe(self) -> None:
+        state = _stale_rehearsal_state(pause=True)
+        self.assertFalse(start_bridge._is_safe_stale_fallback_state(state))
+
+    def test_pending_request_hash_is_not_safe(self) -> None:
+        state = _stale_rehearsal_state(pending_request_hash="abc123")
+        self.assertFalse(start_bridge._is_safe_stale_fallback_state(state))
+
+    def test_pending_handoff_hash_is_not_safe(self) -> None:
+        state = _stale_rehearsal_state(pending_handoff_hash="def456")
+        self.assertFalse(start_bridge._is_safe_stale_fallback_state(state))
+
+    def test_pending_generation_id_is_not_safe(self) -> None:
+        state = _stale_rehearsal_state(last_issue_centric_pending_generation_id="gen-001")
+        self.assertFalse(start_bridge._is_safe_stale_fallback_state(state))
+
+    def test_prepared_generation_id_is_not_safe(self) -> None:
+        state = _stale_rehearsal_state(last_issue_centric_prepared_generation_id="gen-002")
+        self.assertFalse(start_bridge._is_safe_stale_fallback_state(state))
+
+    def test_clean_idle_state_is_not_reset(self) -> None:
+        """DEFAULT_STATE (idle + need_chatgpt_prompt=True) should not be treated as stale."""
+        state = _bridge_common.DEFAULT_STATE.copy()
+        # DEFAULT_STATE already has need_chatgpt_prompt=True → action = request_next_prompt, not no_action
+        self.assertFalse(start_bridge._is_safe_stale_fallback_state(state))
+
+
+class ResetStaleFallbackFreshStartTests(unittest.TestCase):
+    """reset_stale_fallback_for_fresh_start() transitions stale state to idle."""
+
+    def _write_state(self, root: Path, state: dict) -> Path:
+        state_path = root / "bridge" / "state.json"
+        state_path.write_text(json.dumps(state), encoding="utf-8")
+        return state_path
+
+    def test_stale_rehearsal_state_is_reset_to_idle(self) -> None:
+        with tempfile.TemporaryDirectory() as tmp:
+            root = Path(tmp)
+            _make_bridge_env(root)
+            state_path = self._write_state(root, _stale_rehearsal_state())
+
+            original_runtime_root = _bridge_common.bridge_runtime_root
+            _bridge_common._RUNTIME_ROOT_OVERRIDE = root  # type: ignore[attr-defined]
+            try:
+                import importlib
+                importlib.reload(_bridge_common)
+                # Re-patch after reload
+                state_path = root / "bridge" / "state.json"
+                state_path.write_text(json.dumps(_stale_rehearsal_state()), encoding="utf-8")
+
+                # Directly test via patching bridge_runtime_root
+                with unittest.mock.patch.object(
+                    _bridge_common,
+                    "bridge_runtime_root",
+                    return_value=root,
+                ):
+                    result = start_bridge.reset_stale_fallback_for_fresh_start(_args())
+                    self.assertTrue(result)
+                    after = json.loads(state_path.read_text(encoding="utf-8"))
+                    self.assertEqual(after["mode"], "idle")
+                    self.assertTrue(after["need_chatgpt_prompt"])
+            finally:
+                importlib.reload(_bridge_common)
+
+    def test_skipped_for_status_flag(self) -> None:
+        with tempfile.TemporaryDirectory() as tmp:
+            root = Path(tmp)
+            _make_bridge_env(root)
+            state_path = self._write_state(root, _stale_rehearsal_state())
+            import unittest.mock
+            with unittest.mock.patch.object(
+                _bridge_common,
+                "bridge_runtime_root",
+                return_value=root,
+            ):
+                result = start_bridge.reset_stale_fallback_for_fresh_start(_args(status=True))
+                self.assertFalse(result)
+                after = json.loads(state_path.read_text(encoding="utf-8"))
+                self.assertEqual(after["mode"], "awaiting_user")
+
+    def test_skipped_for_doctor_flag(self) -> None:
+        with tempfile.TemporaryDirectory() as tmp:
+            root = Path(tmp)
+            _make_bridge_env(root)
+            state_path = self._write_state(root, _stale_rehearsal_state())
+            import unittest.mock
+            with unittest.mock.patch.object(
+                _bridge_common,
+                "bridge_runtime_root",
+                return_value=root,
+            ):
+                result = start_bridge.reset_stale_fallback_for_fresh_start(_args(doctor=True))
+                self.assertFalse(result)
+                after = json.loads(state_path.read_text(encoding="utf-8"))
+                self.assertEqual(after["mode"], "awaiting_user")
+
+    def test_genuine_pending_request_not_reset(self) -> None:
+        """State with a genuine pending request should not be reset."""
+        with tempfile.TemporaryDirectory() as tmp:
+            root = Path(tmp)
+            _make_bridge_env(root)
+            state = _stale_rehearsal_state(
+                mode="waiting_prompt_reply",
+                pending_request_hash="abc123",
+                pending_request_log="some pending request",
+            )
+            state_path = self._write_state(root, state)
+            import unittest.mock
+            with unittest.mock.patch.object(
+                _bridge_common,
+                "bridge_runtime_root",
+                return_value=root,
+            ):
+                result = start_bridge.reset_stale_fallback_for_fresh_start(_args())
+                self.assertFalse(result)
+                after = json.loads(state_path.read_text(encoding="utf-8"))
+                self.assertEqual(after["mode"], "waiting_prompt_reply")
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
## 概要

PromptWeave の `start_bridge.py --project-path` 実行時に、rehearsal 完了後の `state.json` が残留して fresh-start に入れない問題を修正します。

## exact cause

状態: rehearsal 後に `state.json` が `mode=awaiting_user` + stale `last_issue_centric_*` fields を保持

フロー:
1. `_has_issue_centric_runtime_mode_candidate_state()` → True（古いフィールドが残っている）
2. `resolve_issue_centric_runtime_mode()` → snapshot が無効 → `fallback_legacy`
3. `resolve_fallback_legacy_transition(mode='awaiting_user')` → いずれの条件も不一致 → `no_action`
4. run loop が即座に停止

## 修正内容

`scripts/start_bridge.py` に以下を追加:

- `_is_safe_stale_fallback_state(state)`: 保留なし＋no_action の状態かを判定
- `reset_stale_fallback_for_fresh_start(args)`: 安全なら `mode=idle` + `need_chatgpt_prompt=True` にリセット
- `main()` 内で `recover_resume_from_pending_issue_centric_codex_dispatch` の後に呼び出し

## 安全条件

以下が **すべて** 成立する場合のみリセット（genuine continuation 状態は壊さない）:
- `resolve_unified_next_action() == 'no_action'`
- `error=false`, `pause=false`
- `pending_request_hash` なし
- `pending_handoff_hash` なし
- `last_issue_centric_pending_generation_id` なし
- `last_issue_centric_prepared_generation_id` なし
- active Codex lifecycle mode（ready_for_codex / codex_running / codex_done）でない

## テスト

`tests/test_start_bridge_stale_fallback_reset.py` 13 ケース追加（全 pass）